### PR TITLE
#46 :sparkles: feat: 용어 퀴즈, 기사 내용 퀴즈를 생성하지 않은 기사는 불러오지 않는 로직 추가

### DIFF
--- a/src/main/java/com/finsight/finsight/domain/naver/domain/service/ArticleQueryDslImpl.java
+++ b/src/main/java/com/finsight/finsight/domain/naver/domain/service/ArticleQueryDslImpl.java
@@ -1,29 +1,31 @@
-    package com.finsight.finsight.domain.naver.domain.service;
+package com.finsight.finsight.domain.naver.domain.service;
 
-    import com.finsight.finsight.domain.ai.persistence.entity.QAiArticleSummaryEntity;
-    import com.finsight.finsight.domain.learning.domain.constant.Category;
-    import com.finsight.finsight.domain.learning.domain.constant.SortType;
-    import com.finsight.finsight.domain.learning.domain.service.CursorParser;
-    import com.finsight.finsight.domain.naver.domain.constant.NaverEconomySection;
-    import com.finsight.finsight.domain.naver.persistence.entity.NaverArticleEntity;
-    import com.finsight.finsight.domain.naver.persistence.entity.QNaverArticleEntity;
-    import com.finsight.finsight.domain.ai.persistence.entity.QAiTermCardEntity;
-    import com.querydsl.core.BooleanBuilder;
-    import com.querydsl.core.types.OrderSpecifier;
-    import com.querydsl.core.types.Predicate;
-    import com.querydsl.jpa.JPAExpressions;
-    import com.querydsl.jpa.impl.JPAQueryFactory;
-    import lombok.RequiredArgsConstructor;
-    import org.springframework.data.domain.Page;
-    import org.springframework.data.domain.PageImpl;
-    import org.springframework.data.domain.PageRequest;
-    import org.springframework.stereotype.Service;
+import com.finsight.finsight.domain.ai.persistence.entity.AiJobType;
+import com.finsight.finsight.domain.ai.persistence.entity.QAiArticleSummaryEntity;
+import com.finsight.finsight.domain.ai.persistence.entity.QAiQuizSetEntity;
+import com.finsight.finsight.domain.learning.domain.constant.Category;
+import com.finsight.finsight.domain.learning.domain.constant.SortType;
+import com.finsight.finsight.domain.learning.domain.service.CursorParser;
+import com.finsight.finsight.domain.naver.domain.constant.NaverEconomySection;
+import com.finsight.finsight.domain.naver.persistence.entity.NaverArticleEntity;
+import com.finsight.finsight.domain.naver.persistence.entity.QNaverArticleEntity;
+import com.finsight.finsight.domain.ai.persistence.entity.QAiTermCardEntity;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
 
-    import java.util.List;
+import java.util.List;
 
-    @Service
-    @RequiredArgsConstructor
-    public class ArticleQueryDslImpl implements ArticleQueryDsl{
+@Service
+@RequiredArgsConstructor
+public class ArticleQueryDslImpl implements ArticleQueryDsl {
 
         private final JPAQueryFactory queryFactory;
 
@@ -34,78 +36,90 @@
                 SortType sort,
                 int size,
                 CursorParser.NewsCursor cursor
-        ){
-            // Q클래스 선언
-            QNaverArticleEntity naverArticleEntity = QNaverArticleEntity.naverArticleEntity;
+        ) {
+                // Q클래스 선언
+                QNaverArticleEntity naverArticleEntity = QNaverArticleEntity.naverArticleEntity;
 
-            Predicate predicate = buildPredicate(naverArticleEntity, category, sort, cursor);
+                Predicate predicate = buildPredicate(naverArticleEntity, category, sort, cursor);
 
-            return queryFactory
-                    .selectFrom(naverArticleEntity)
-                    .where(predicate)
-                    .orderBy(orderSpecifiers(naverArticleEntity, sort))
-                    .limit(size + 1L) // size+1: hasNext 판별용
-                    .fetch();
+                return queryFactory
+                        .selectFrom(naverArticleEntity)
+                        .where(predicate)
+                        .orderBy(orderSpecifiers(naverArticleEntity, sort))
+                        .limit(size + 1L) // size+1: hasNext 판별용
+                        .fetch();
         }
 
         @Override
-        public Page<NaverArticleEntity> findSearchNews(SortType sort, int page, int size, String keyword){
+        public Page<NaverArticleEntity> findSearchNews(SortType sort, int page, int size, String keyword) {
 
-            // Q클래스 선언
-            QNaverArticleEntity naverArticleEntity = QNaverArticleEntity.naverArticleEntity;
+                // Q클래스 선언
+                QNaverArticleEntity naverArticleEntity = QNaverArticleEntity.naverArticleEntity;
 
-            BooleanBuilder builder = new BooleanBuilder();
+                BooleanBuilder builder = new BooleanBuilder();
 
-            if (keyword != null && !keyword.isBlank()) {
-                QAiTermCardEntity qAiTermCard = QAiTermCardEntity.aiTermCardEntity;
-                QAiArticleSummaryEntity qSummary = QAiArticleSummaryEntity.aiArticleSummaryEntity;
+                if (keyword != null && !keyword.isBlank()) {
+                        QAiTermCardEntity qAiTermCard = QAiTermCardEntity.aiTermCardEntity;
+                        QAiArticleSummaryEntity qSummary = QAiArticleSummaryEntity.aiArticleSummaryEntity;
 
-                // 제목에 포함되는 경우
-                builder.and(naverArticleEntity.title.contains(keyword)
-                        .or(JPAExpressions.selectOne() // 2. 용어 카드들 중에 키워드를 포함하는 용어가 하나라도 존재하는 경우
-                                .from(qAiTermCard)
-                                .where(
-                                        qAiTermCard.article.eq(naverArticleEntity) // 현재 기사와 연결된 용어 중
-                                                .and(qAiTermCard.term.displayName.contains(keyword)) // 용어명이 키워드를 포함
-                                ).exists())
-                        .or(JPAExpressions.selectOne() // 3. 본문/요약 검색 (exists)
-                                .from(qSummary)
-                                .where(qSummary.article.eq(naverArticleEntity)
-                                        .and(qSummary.summaryFull.contains(keyword) // 전체 요약 검색
-                                                .or(qSummary.summary3Lines.contains(keyword)))) // 3줄 요약 검색
-                                .exists()));
-            }
+                        // 제목에 포함되는 경우 또는 용어 카드 포함 또는 요약문 포함
+                        builder.and(naverArticleEntity.title.contains(keyword)
+                                .or(JPAExpressions.selectOne()
+                                        .from(qAiTermCard)
+                                        .where(
+                                                qAiTermCard.article.eq(naverArticleEntity)
+                                                        .and(qAiTermCard.term.displayName.contains(keyword))
+                                        ).exists())
+                                .or(JPAExpressions.selectOne()
+                                        .from(qSummary)
+                                        .where(qSummary.article.eq(naverArticleEntity)
+                                                .and(qSummary.summaryFull.contains(keyword)
+                                                        .or(qSummary.summary3Lines.contains(keyword))))
+                                        .exists()));
+                }
 
-            // 용어 카드 3개 이상 조건
-            QAiTermCardEntity qAiTermCardEntity = QAiTermCardEntity.aiTermCardEntity;
-            builder.and(naverArticleEntity.id.in(
-                    JPAExpressions.select(qAiTermCardEntity.article.id)
-                            .from(qAiTermCardEntity)
-                            .groupBy(qAiTermCardEntity.article.id)
-                            .having(qAiTermCardEntity.count().goe(3L))));
+                // 용어 카드 3개 이상 조건
+                QAiTermCardEntity qAiTermCardEntity = QAiTermCardEntity.aiTermCardEntity;
+                builder.and(naverArticleEntity.id.in(
+                        JPAExpressions.select(qAiTermCardEntity.article.id)
+                                .from(qAiTermCardEntity)
+                                .groupBy(qAiTermCardEntity.article.id)
+                                .having(qAiTermCardEntity.count().goe(3L))));
 
-            // 2. 콘텐츠 조회 (Offset 기반)
-            List<NaverArticleEntity> content = queryFactory
-                    .selectFrom(naverArticleEntity)
-                    .where(builder)
-                    .orderBy(orderSpecifiers(naverArticleEntity, sort))
-                    .offset((long) page * size)
-                    .limit(size)
-                    .fetch();
+                // 퀴즈 생성 여부 (내용 퀴즈 & 용어 퀴즈)
+                QAiQuizSetEntity qAiQuizSetEntity = QAiQuizSetEntity.aiQuizSetEntity;
+                builder.and(JPAExpressions.selectOne()
+                        .from(qAiQuizSetEntity)
+                        .where(qAiQuizSetEntity.article.eq(naverArticleEntity)
+                                .and(qAiQuizSetEntity.quizKind.eq(AiJobType.QUIZ_CONTENT)))
+                        .exists());
 
-            // 3. 전체 개수 조회
-            Long total = queryFactory
-                    .select(naverArticleEntity.count())
-                    .from(naverArticleEntity)
-                    .where(builder)
-                    .fetchOne();
+                builder.and(JPAExpressions.selectOne()
+                        .from(qAiQuizSetEntity)
+                        .where(qAiQuizSetEntity.article.eq(naverArticleEntity)
+                                .and(qAiQuizSetEntity.quizKind.eq(AiJobType.QUIZ_TERM)))
+                        .exists());
 
-            long totalCount = (total != null) ? total : 0L;
+                // 2. 콘텐츠 조회 (Offset 기반)
+                List<NaverArticleEntity> content = queryFactory
+                        .selectFrom(naverArticleEntity)
+                        .where(builder)
+                        .orderBy(orderSpecifiers(naverArticleEntity, sort))
+                        .offset((long) page * size)
+                        .limit(size)
+                        .fetch();
 
-            // 4. PageImpl 객체로 감싸서 반환
-            return new PageImpl<>(content, PageRequest.of(page, size), totalCount);
+                // 3. 전체 개수 조회
+                Long total = queryFactory
+                        .select(naverArticleEntity.count())
+                        .from(naverArticleEntity)
+                        .where(builder)
+                        .fetchOne();
 
+                long totalCount = (total != null) ? total : 0L;
 
+                // 4. PageImpl 객체로 감싸서 반환
+                return new PageImpl<>(content, PageRequest.of(page, size), totalCount);
         }
 
         // predicate 제작, where 절 (카테고리별 / 페이지 별)
@@ -115,56 +129,70 @@
                 SortType sort,
                 CursorParser.NewsCursor cursor
         ) {
-            BooleanBuilder builder = new BooleanBuilder();
+                BooleanBuilder builder = new BooleanBuilder();
 
-            // 1) 카테고리 조건
-            if (category != null && category != Category.ALL) {
-                NaverEconomySection section = NaverEconomySection.valueOf(category.name());
-                builder.and(naverArticleEntity.section.eq(section));
-            }
+                // 1) 카테고리 조건
+                if (category != null && category != Category.ALL) {
+                        NaverEconomySection section = NaverEconomySection.valueOf(category.name());
+                        builder.and(naverArticleEntity.section.eq(section));
+                }
 
-            // 2) 커서 조건
-            if (cursor != null && !cursor.isEmpty()) {
-                builder.and(cursorPredicate(naverArticleEntity, sort, cursor));
-            }
+                // 2) 커서 조건
+                if (cursor != null && !cursor.isEmpty()) {
+                        builder.and(cursorPredicate(naverArticleEntity, sort, cursor));
+                }
 
-            // 3) 용어 카드 3개 이상 조건
-            QAiTermCardEntity qAiTermCardEntity = QAiTermCardEntity.aiTermCardEntity;
-            builder.and(naverArticleEntity.id.in(
-                    JPAExpressions.select(qAiTermCardEntity.article.id)
-                            .from(qAiTermCardEntity)
-                            .groupBy(qAiTermCardEntity.article.id)
-                            .having(qAiTermCardEntity.count().goe(3L))));
+                // 3) 용어 카드 3개 이상 조건
+                QAiTermCardEntity qAiTermCardEntity = QAiTermCardEntity.aiTermCardEntity;
+                builder.and(naverArticleEntity.id.in(
+                        JPAExpressions.select(qAiTermCardEntity.article.id)
+                                .from(qAiTermCardEntity)
+                                .groupBy(qAiTermCardEntity.article.id)
+                                .having(qAiTermCardEntity.count().goe(3L))));
 
-            return builder;
+                // 4) 퀴즈 생성 여부 (내용 퀴즈 & 용어 퀴즈)
+                QAiQuizSetEntity qAiQuizSetEntity = QAiQuizSetEntity.aiQuizSetEntity;
+                builder.and(JPAExpressions.selectOne()
+                        .from(qAiQuizSetEntity)
+                        .where(qAiQuizSetEntity.article.eq(naverArticleEntity)
+                                .and(qAiQuizSetEntity.quizKind.eq(AiJobType.QUIZ_CONTENT)))
+                        .exists());
+
+                builder.and(JPAExpressions.selectOne()
+                        .from(qAiQuizSetEntity)
+                        .where(qAiQuizSetEntity.article.eq(naverArticleEntity)
+                                .and(qAiQuizSetEntity.quizKind.eq(AiJobType.QUIZ_TERM)))
+                        .exists());
+
+                return builder;
         }
 
         // 커서 조건(최신순/인기순)
         private Predicate cursorPredicate(QNaverArticleEntity naverArticleEntity, SortType sort, CursorParser.NewsCursor cursor) {
-            return switch (sort) {
-                case LATEST -> (
-                        naverArticleEntity.publishedAt.lt(cursor.lastPublishedAt())
-                                .or(naverArticleEntity.publishedAt.eq(cursor.lastPublishedAt()).and(naverArticleEntity.id.lt(cursor.lastId())))
-                );
+                return switch (sort) {
+                        case LATEST -> (
+                                naverArticleEntity.publishedAt.lt(cursor.lastPublishedAt())
+                                        .or(naverArticleEntity.publishedAt.eq(cursor.lastPublishedAt()).and(naverArticleEntity.id.lt(cursor.lastId())))
+                        );
 
-                case POPULARITY -> (
-                        naverArticleEntity.viewCount.lt(cursor.viewCount())
-                                .or(naverArticleEntity.viewCount.eq(cursor.viewCount()).and(naverArticleEntity.id.lt(cursor.lastId())))
-                );
-            };
+                        case POPULARITY -> (
+                                naverArticleEntity.viewCount.lt(cursor.viewCount())
+                                        .or(naverArticleEntity.viewCount.eq(cursor.viewCount()).and(naverArticleEntity.id.lt(cursor.lastId())))
+                        );
+                };
         }
 
         // 정렬하기, orderBy 절 (최신순/인기순)
         private OrderSpecifier<?>[] orderSpecifiers(QNaverArticleEntity naverArticleEntity, SortType sort) {
-            return switch (sort) {
-                case LATEST -> new OrderSpecifier<?>[]{
-                        naverArticleEntity.publishedAt.desc(),
-                        naverArticleEntity.id.desc()
+                return switch (sort) {
+                        case LATEST -> new OrderSpecifier<?>[]{
+                                naverArticleEntity.publishedAt.desc(),
+                                naverArticleEntity.id.desc()
+                        };
+                        case POPULARITY -> new OrderSpecifier<?>[]{
+                                naverArticleEntity.viewCount.desc(),
+                                naverArticleEntity.id.desc()
+                        };
                 };
-                case POPULARITY -> new OrderSpecifier<?>[]{
-                        naverArticleEntity.viewCount.desc(),
-                        naverArticleEntity.id.desc()
-                };
-            };
         }
-    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #46 

## 📌 개요

- 용어 및 기사 내용 퀴즈를 생성하지 않은 기사도 조회 결과에서 제외

## 🔁 변경 사항

## 📸 스크린샷
- 가장 최근 뉴스 조회
<img width="1441" height="614" alt="image" src="https://github.com/user-attachments/assets/d26f5bba-aa8f-4631-b3f1-d4b4a8453be8" />
- 결과(newsId = 13942)
<img width="1317" height="448" alt="image" src="https://github.com/user-attachments/assets/db050c31-74de-4797-852b-2e70d57f7b28" />

- 생성된 뉴스 기사인지 확인
<img width="1441" height="483" alt="image" src="https://github.com/user-attachments/assets/5da1dd41-5dd8-4285-917d-58e592dd4dda" />
- 결과
<img width="1398" height="574" alt="image" src="https://github.com/user-attachments/assets/fb11db7e-f97a-4d39-ac18-841945f77c56" />



## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **기능 개선**
  * 기사 검색 조건이 확대되어 제목, 관련 용어 카드, 기사 요약본을 포함한 검색이 가능하게 개선되었습니다.
  * 퀴즈가 포함된 기사 검색 기능이 추가되었습니다.
  * 용어 카드 3개 이상이 포함된 기사를 보다 정확하게 필터링할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->