### PR TITLE
Feat/#48 home

### DIFF
--- a/src/main/java/com/finsight/finsight/domain/home/application/dto/response/HomeResponseDTO.java
+++ b/src/main/java/com/finsight/finsight/domain/home/application/dto/response/HomeResponseDTO.java
@@ -70,4 +70,12 @@ public class HomeResponseDTO {
             int unsolvedCount
     ) {
     }
+
+    @Schema(name = "DailyChecklistResponse")
+    @Builder
+    public record DailyChecklistResponse(
+            boolean isNewsSaved,    // 뉴스 1개 저장하기
+            boolean isQuizSolved,   // 퀴즈 1개 풀기
+            boolean isQuizReviewed  // 보관한 퀴즈 복습하기
+    ) {}
 }

--- a/src/main/java/com/finsight/finsight/domain/home/presentation/HomeController.java
+++ b/src/main/java/com/finsight/finsight/domain/home/presentation/HomeController.java
@@ -99,4 +99,26 @@ public class HomeController {
                 DataResponse.from(homeNewsService.getHomeStatus(userDetails.getUserId()))
         );
     }
+
+    @Operation(
+            summary = "일일 체크리스트 조회",
+            description = """
+                    오늘의 일일 미션 달성 여부를 조회합니다.
+                    1. 뉴스 1개 저장하기
+                    2. 퀴즈 1개 풀기 (신규)
+                    3. 보관한 퀴즈 복습하기 (기존 기록 업데이트)
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "체크리스트 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음")
+    })
+    @GetMapping("/checklist")
+    public ResponseEntity<DataResponse<HomeResponseDTO.DailyChecklistResponse>> getDailyChecklist(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(
+                DataResponse.from(homeNewsService.getDailyChecklist(userDetails.getUserId()))
+        );
+    }
 }

--- a/src/main/java/com/finsight/finsight/domain/quiz/persistence/entity/QuizAttemptEntity.java
+++ b/src/main/java/com/finsight/finsight/domain/quiz/persistence/entity/QuizAttemptEntity.java
@@ -44,7 +44,11 @@ public class QuizAttemptEntity {
     @Column(name = "score", nullable = false)
     private Integer score;
 
-    /** 풀이 시각 */
+    /** 최초 풀이 시각 (생성 시 고정) */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /** 풀이 시각 (복습시 업데이트) */
     @Column(name = "attempted_at", nullable = false)
     private LocalDateTime attemptedAt;
 
@@ -56,6 +60,7 @@ public class QuizAttemptEntity {
         this.answersJson = answersJson;
         this.correctCount = correctCount;
         this.score = score;
+        this.createdAt = LocalDateTime.now();
         this.attemptedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/finsight/finsight/domain/quiz/persistence/repository/QuizAttemptRepository.java
+++ b/src/main/java/com/finsight/finsight/domain/quiz/persistence/repository/QuizAttemptRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,4 +21,14 @@ public interface QuizAttemptRepository extends JpaRepository<QuizAttemptEntity, 
     /** N+1 방지를 위해 여러 기사 ID에 대한 풀이 완료된 기사 ID 목록 조회 */
     @Query("SELECT DISTINCT qa.quizSet.article.id FROM QuizAttemptEntity qa WHERE qa.user.userId = :userId AND qa.quizSet.article.id IN :articleIds")
     List<Long> findSolvedArticleIds(@Param("userId") Long userId, @Param("articleIds") List<Long> articleIds);
+
+    // 일일퀘스트 : 오늘 '신규'로 퀴즈를 풀었는지 확인
+    // 오늘 풀었으며(attemptedAt), 해당 기록이 오늘 처음 생성된 경우(createdAt == attemptedAt)를 찾습니다.
+    @Query("SELECT COUNT(qa) > 0 FROM QuizAttemptEntity qa WHERE qa.user.userId = :userId AND qa.attemptedAt >= :startOfToday AND qa.createdAt >= :startOfToday")
+    boolean existsNewAttemptToday(@Param("userId") Long userId, @Param("startOfToday") LocalDateTime startOfToday);
+
+    // 일일퀘스트 : 오늘 '복습'을 완료했는지 확인
+    // 오늘 다시 풀었지만(attemptedAt), 실제 데이터 생성일(createdAt)은 오늘 이전인 경우입니다.
+    @Query("SELECT COUNT(qa) > 0 FROM QuizAttemptEntity qa WHERE qa.user.userId = :userId AND qa.attemptedAt >= :startOfToday AND qa.createdAt < :startOfToday")
+    boolean existsReviewAttemptToday(@Param("userId") Long userId, @Param("startOfToday") LocalDateTime startOfToday);
 }

--- a/src/main/java/com/finsight/finsight/domain/storage/persistence/repository/FolderItemRepository.java
+++ b/src/main/java/com/finsight/finsight/domain/storage/persistence/repository/FolderItemRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -108,4 +109,10 @@ public interface FolderItemRepository extends JpaRepository<FolderItemEntity, Lo
             @Param("userId") Long userId,
             @Param("query") String query,
             Pageable pageable);
+
+    // ========== 일일퀘스트 ==========
+    // 오늘 뉴스 저장 여부 확인
+    // savedAt이 특정 시점(오늘 00시) 이후인 기록이 있는지 확인합니다.
+    @Query("SELECT COUNT(fi) > 0 FROM FolderItemEntity fi WHERE fi.folder.user.userId = :userId AND fi.itemType = :itemType AND fi.savedAt >= :since")
+    boolean existsByUserIdAndItemTypeAndSavedAtAfter(@Param("userId") Long userId, @Param("itemType") FolderType itemType, @Param("since") LocalDateTime since);
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #48 

## 📌 개요

- 홈 화면 상태 메시지 및 일일 체크리스트 기능 구현

## 🔁 변경 사항

1. 홈 상태 메시지 API (/api/home/status) 구현
2. 일일 체크리스트 API (/api/home/checklist) 구현
3. 엔티티 수정
QuizAttemptEntity: '최초 풀이 시점'을 보존하기 위해 createdAt 필드를 추가

## 📸 스크린샷
<img width="1015" height="300" alt="스크린샷 2026-01-27 오후 8 29 04" src="https://github.com/user-attachments/assets/12b05073-279b-41c8-b3ac-8bea70c28e59" />


## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 홈 상태 조회 API 추가: 저장된 기사 및 미완료 기사 수 표시
  * 일일 체크리스트 API 추가: 오늘 저장한 뉴스, 풀이한 퀴즈, 복습한 퀴즈 현황 추적
  * 퀴즈 풀이 시간 기록 강화: 최초 풀이 시간과 복습 시간 구분

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->