### PR TITLE
Refactor/#59 authentication 

### DIFF
--- a/src/main/java/com/finsight/finsight/global/config/SecurityConfig.java
+++ b/src/main/java/com/finsight/finsight/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.finsight.finsight.global.config;
 
+import com.finsight.finsight.global.security.CustomAuthenticationEntryPoint;
 import com.finsight.finsight.global.security.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -20,6 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -39,6 +41,9 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                )
                 .authorizeHttpRequests(auth -> auth
                         // 프리플라이트 통과
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/src/main/java/com/finsight/finsight/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/finsight/finsight/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.finsight.finsight.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.finsight.finsight.domain.auth.exception.code.AuthErrorCode;
+import com.finsight.finsight.global.response.ErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        AuthErrorCode errorCode = AuthErrorCode.UNAUTHORIZED;
+
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode, request);
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}


### PR DESCRIPTION
…ionHandling 추가

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #59 

## 📌 개요

인증되지 않은 요청(Access Token 에러)에 대해 일관된 에러 응답 (AUTH-011)을 반환하도록 수정했습니다.

## 🔁 변경 사항

CustomAuthenticationEntryPoint 추가
- 인증 실패 시 기본 응답 대신 AUTH-011 응답 형식으로 반환

SecurityConfig 수정
- exceptionHandling에 CunstomAuthenticationEntryPoint 등록

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 실패 시 표준화된 JSON 형식의 오류 응답 반환
  * HTTP 401 Unauthorized 상태 코드와 적절한 콘텐츠 타입으로 오류 응답 개선
  * 일관된 오류 메시지 형식 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->