### PR TITLE
Feat/#48 home

### DIFF
--- a/src/main/java/com/finsight/finsight/domain/home/domain/service/HomeNewsService.java
+++ b/src/main/java/com/finsight/finsight/domain/home/domain/service/HomeNewsService.java
@@ -19,6 +19,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.finsight.finsight.domain.home.exception.HomeException;
+import com.finsight.finsight.domain.home.exception.code.HomeErrorCode;
+
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -147,6 +150,16 @@ public class HomeNewsService {
         List<NaverArticleEntity> articles;
 
         if (category != null) {
+            // 사용자 관심 카테고리에 포함되는지 검증
+            boolean isUserCategory = userCategoryRepository.findByUserUserId(userId)
+                    .stream()
+                    .map(UserCategoryEntity::getSection)
+                    .anyMatch(section -> section == category);
+
+            if (!isUserCategory) {
+                throw new HomeException(HomeErrorCode.CATEGORY_NOT_IN_USER_INTEREST);
+            }
+
             // 특정 카테고리: 최신순 8개
             articles = naverArticleRepository.findTopLatestBySection(category, PERSONALIZED_NEWS_SIZE);
         } else {

--- a/src/main/java/com/finsight/finsight/domain/home/exception/HomeException.java
+++ b/src/main/java/com/finsight/finsight/domain/home/exception/HomeException.java
@@ -1,0 +1,10 @@
+package com.finsight.finsight.domain.home.exception;
+
+import com.finsight.finsight.global.exception.AppException;
+import com.finsight.finsight.global.exception.BaseErrorCode;
+
+public class HomeException extends AppException {
+    public HomeException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/finsight/finsight/domain/home/exception/code/HomeErrorCode.java
+++ b/src/main/java/com/finsight/finsight/domain/home/exception/code/HomeErrorCode.java
@@ -1,0 +1,17 @@
+package com.finsight.finsight.domain.home.exception.code;
+
+import com.finsight.finsight.global.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum HomeErrorCode implements BaseErrorCode {
+
+    CATEGORY_NOT_IN_USER_INTEREST(HttpStatus.BAD_REQUEST, "사용자의 관심 카테고리에 포함되지 않은 카테고리입니다.", "HOME-001");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final String code;
+}

--- a/src/main/java/com/finsight/finsight/domain/home/presentation/HomeController.java
+++ b/src/main/java/com/finsight/finsight/domain/home/presentation/HomeController.java
@@ -71,7 +71,8 @@ public class HomeController {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "맞춤 뉴스 조회 성공"),
-            @ApiResponse(responseCode = "401", description = "접근 권한 없음(AUTH-011)")
+            @ApiResponse(responseCode = "401", description = "접근 권한 없음(AUTH-011)"),
+            @ApiResponse(responseCode = "400", description = "사용자 관심 카테고리가 아님(HOME-001)"),
     })
     @GetMapping("/news/personalized")
     public ResponseEntity<DataResponse<HomeResponseDTO.PersonalizedNewsResponse>> getPersonalizedNews(


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #48 

## 📌 개요

- 홈 관련 api

## 🔁 변경 사항

- 홈 맞춤뉴스 : 사용자 관심분야 아닌 거 조회 시 에러 반환
- 홈 컨트롤러 : ApiResponse 변경

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 사용자의 관심 카테고리에 포함되지 않은 카테고리에서 뉴스를 요청할 때, 명확한 오류 메시지와 함께 적절한 응답이 반환됩니다.

## 개선사항
* API 오류 응답 처리가 개선되어 다양한 요청 상황에서 더 정확하고 일관성 있는 오류 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->