### PR TITLE
#67 :sparkles: feat: 기사 상세 조회 시 날짜 포멧 통일 및 썸네일과 원문 링크 응답에 추가

### DIFF
--- a/src/main/java/com/finsight/finsight/domain/learning/application/dto/response/LearningResponseDTO.java
+++ b/src/main/java/com/finsight/finsight/domain/learning/application/dto/response/LearningResponseDTO.java
@@ -61,6 +61,8 @@ public class LearningResponseDTO {
                         List<CoreTerm> coreTerms,
                         String title,
                         String date,
+                        String thumbnailUrl,
+                        String originalUrl,
                         Summary3Lines summary3Lines,
                         String bodySummary,
                         List<Insight> insights) {

--- a/src/main/java/com/finsight/finsight/domain/learning/persistence/mapper/LearningConverter.java
+++ b/src/main/java/com/finsight/finsight/domain/learning/persistence/mapper/LearningConverter.java
@@ -9,6 +9,9 @@ import com.finsight.finsight.domain.ai.persistence.entity.AiArticleSummaryEntity
 import com.finsight.finsight.domain.ai.persistence.entity.AiArticleInsightEntity;
 
 import java.util.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,6 +23,10 @@ import org.springframework.stereotype.Component;
 public class LearningConverter {
 
     private final ObjectMapper objectMapper;
+
+    // 한국어 날짜 포맷터: "2026.01.01. 오후 4:51"
+    private static final DateTimeFormatter KOREAN_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd. a h:mm",
+            Locale.KOREAN);
 
     // 단일 엔티티 -> NewsItem DTO
     public static LearningResponseDTO.NewsItem toNewsItem(NaverArticleEntity entity, List<AiTermCardEntity> terms) {
@@ -111,11 +118,21 @@ public class LearningConverter {
                                 .build())
                         .toList())
                 .title(article.getTitle())
-                .date(article.getPublishedAt().toString())
+                .date(formatKoreanDate(article.getPublishedAt()))
+                .thumbnailUrl(article.getThumbnailUrl())
+                .originalUrl(article.getUrl())
                 .summary3Lines(parseSummary3Lines(summary.getSummary3Lines()))
                 .bodySummary(summary.getSummaryFull())
                 .insights(parseInsights(insight.getInsightJson()))
                 .build();
+    }
+
+    // LocalDateTime을 한국어 형식 날짜로 변환
+    private String formatKoreanDate(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return "";
+        }
+        return dateTime.format(KOREAN_DATE_FORMATTER);
     }
 
     private LearningResponseDTO.Summary3Lines parseSummary3Lines(String rawText) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #67 

## 📌 개요

- 기사  상세 조회 시 날짜 포멧 통일과 썸네일 url, 원문 링크를 응답에 추가하였습니다.

## 🔁 변경 사항

## 📸 스크린샷
<img width="1495" height="504" alt="image" src="https://github.com/user-attachments/assets/c7a77388-dc6a-432e-a7e5-17838c0a3dee" />

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 뉴스 상세 정보에 썸네일 이미지 URL과 원본 기사 URL 필드 추가
  * 뉴스 날짜 표시를 한국식 형식으로 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->