### PR TITLE
#74 ✨ feat: item이 저장된 폴더 목록 반환 api 추가

### DIFF
--- a/src/main/java/com/finsight/finsight/domain/storage/presentation/FolderController.java
+++ b/src/main/java/com/finsight/finsight/domain/storage/presentation/FolderController.java
@@ -77,4 +77,15 @@ public class FolderController {
         List<FolderResponse> response = folderService.updateFolderOrder(userDetails.getUserId(), request);
         return ResponseEntity.ok(DataResponse.from(response));
     }
+
+    @GetMapping("/items/{itemId}")
+    @Operation(summary = "아이템이 저장된 폴더 조회", description = "특정 뉴스/용어가 저장된 폴더 목록을 반환합니다.")
+    public ResponseEntity<DataResponse<List<FolderResponse>>> getItemFolders(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long itemId,
+            @RequestParam String type
+    ) {
+        List<FolderResponse> response = folderService.getItemFolders(userDetails.getUserId(), type, itemId);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #74 

## 📌 개요

특정 뉴스, 용어가 저장된 폴더 목록 조회 api 추가

## 🔁 변경 사항

itemId (뉴스ID or 용어ID) request를 통해 아이템이 저장된 폴더 목록을 조회하는 FolderService, FolderController 추가

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 특정 아이템을 포함하는 폴더 조회 기능 추가
  * 아이템 ID와 타입을 지정하여 해당 아이템이 저장된 모든 폴더를 확인할 수 있습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->