### PR TITLE
fix: 카테고리 순서 변경 시 flush 추가로 유니크 제약 충돌 해결

### DIFF
--- a/src/main/java/com/finsight/finsight/domain/category/domain/service/CategoryService.java
+++ b/src/main/java/com/finsight/finsight/domain/category/domain/service/CategoryService.java
@@ -108,6 +108,7 @@ public class CategoryService {
 
         // 기존 순서 삭제
         userCategoryOrderRepository.deleteByUserUserId(userId);
+        userCategoryOrderRepository.flush();  // 삭제 먼저 DB에 반영
 
         // 새 순서 저장
         for (UpdateCategoryOrderRequest.CategoryOrderItem item : request.orders()) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크


## 📌 개요

카테고리 순서 변경 API 두 번째 요청 시 500 에러 발생하는 버그 수정

## 🔁 변경 사항

카테고리 순서 변경 시 기존 데이터 삭제 후 flush() 추가
JPA 쿼리 실행 순서 문제로 인한 유니크 제약 충돌 해결

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 카테고리 순서 업데이트 시 데이터 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->